### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # intertalk
 
-[![Docker Automated build](https://img.shields.io/docker/automated/blackdoor/intertalk.svg?maxAge=2592000)](https://hub.docker.com/r/blackdoor/intertalk/)
+[![Docker Automated build](https://img.shields.io/docker/automated/blackdoor/intertalk.svg?maxAge=2592000)](https://hub.docker.com/r/blackdoor/intertalk/) [![](https://images.microbadger.com/badges/image/blackdoor/intertalk.svg)](https://microbadger.com/images/blackdoor/intertalk "Get your own image badge on microbadger.com")
 
 A simple standard for allowing users of different messaging services to talk to 
 one another while still allowing the service providers to offer rich features and 
@@ -159,3 +159,4 @@ Send messages with `POST` to `/messages`. The body should be a message object li
 ### Recieving Messages
 
 Establish a websocket connection to `/messageStream`. As soon as you connect send the token from the login. New messages in the conversation will be sent to you as they arrive. All messages will come over this socket (including ones you send).
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [blackdoor/intertalk](https://hub.docker.com/r/blackdoor/intertalk/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/blackdoor/intertalk).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/blackdoor/intertalk.svg)](https://microbadger.com/images/blackdoor/intertalk "Get your own image badge on microbadger.com")
